### PR TITLE
Add arc demo page and various color helper classes

### DIFF
--- a/arcs.html
+++ b/arcs.html
@@ -111,7 +111,6 @@ layout: default
     <div class="row hero rounded bg-mint-lighter border-mint-dark">
       <div class="col-md-12">
         <h4><strong>ARC Ecosystem</strong></h4>
-
         <div class="row">
           <div class="col-md-6">
             <img class="img-fluid mx-md-5 my-4" alt="ARC research cycle" src="/assets/img/arc-ecosystem.svg" />
@@ -128,3 +127,4 @@ layout: default
       </div>
     </div>
   </div>
+</div>

--- a/arcs.html
+++ b/arcs.html
@@ -4,7 +4,7 @@ layout: default
 
 ---
 
-<div class="container-fluid bg-mint">
+<div class="container-fluid">
   <div class="container-md">
     <div class="row hero">
       <div class="col-12">
@@ -36,12 +36,12 @@ layout: default
 </div>
 
 <!-- complete workflow -->
-<div class="container-fluid bg-mint mx-0 py-3">
+<div class="container-fluid bg-split-darkblue mx-0 py-3">
   <div class="container-md">
-    <div class="row hero rounded bg-white">
-      <div class="col-md-12">
+    <div class="row hero rounded bg-mint-lighter border-mint-dark">
+      <div class="col-md-12 p-3">
         <h4><strong>ARCs cover the complete workflow</strong></h4>
-
+        <img class="img-fluid mx-md-5 my-4" alt="ARC research cycle" src="/assets/img/arc-annotation.svg" />
         <span>DataPLANT will path the way from classical paper publication to pure data publication including the
           annotated
           research context.
@@ -52,9 +52,9 @@ layout: default
 </div>
 
 <!-- research cycle -->
-<div class="container-fluid bg-white">
+<div class="container-fluid bg-split-darkblue-rev mx-0 py-3">
   <div class="container-md">
-    <div class="row hero rounded">
+    <div class="row hero rounded bg-lightblue-lighter border-lightblue-dark">
       <div class="col-md-12 p-3">
         <h4><strong>ARC-based research workflow</strong></h2>
           <img class="img-fluid mx-md-5 mb-4" alt="ARC research cycle" src="/assets/img/arc-research-cycle.svg" />
@@ -68,9 +68,9 @@ layout: default
 </div>
 
 <!-- other stuff -->
-<div class="container-fluid bg-mint mx-0 py-3">
+<div class="container-fluid bg-split-darkblue mx-0 py-3">
   <div class="container-md">
-    <div class="row hero rounded bg-white">
+    <div class="row hero rounded bg-yellow-lighter border-yellow-dark">
       <div class="col-md-12">
         <h4><strong>ARCs and Assisted Annotation</strong></h4>
         <img class="img-fluid mx-md-5 my-4" alt="ARC research cycle" src="/assets/img/arc-annotation.svg" />
@@ -87,9 +87,9 @@ layout: default
 </div>
 
 <!-- annotation -->
-<div class="container-fluid bg-white mx-0 py-3">
+<div class="container-fluid bg-split-darkblue-rev mx-0 py-3">
   <div class="container-md">
-    <div class="row hero rounded bg-white">
+    <div class="row hero rounded bg-olive-lighter border-olive-dark">
       <div class="col-md-12">
         <h4><strong>ARCs and Assisted Annotation</strong></h4>
         <img class="img-fluid mx-md-5 my-4" alt="ARC research cycle" src="/assets/img/arc-annotation.svg" />
@@ -106,9 +106,9 @@ layout: default
 </div>
 
 <!-- ARC ecosystem -->
-<div class="container-fluid bg-mint mx-0 py-3">
+<div class="container-fluid bg-split-darkblue mx-0 py-3">
   <div class="container-md">
-    <div class="row hero rounded bg-white">
+    <div class="row hero rounded bg-mint-lighter border-mint-dark">
       <div class="col-md-12">
         <h4><strong>ARC Ecosystem</strong></h4>
 

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -156,6 +156,12 @@ $black: #3A3A3A;
 .bg-olive-dark { background: $olive-darker-50}
 .bg-olive-darker { background: $olive-darker-70}
 
+.bg-split-top-mint{background: linear-gradient($white 20%, $mint 20%)}
+.bg-split-top-lightblue{background: linear-gradient($white 20%, $lightblue 20%)}
+.bg-split-top-darkblue{background: linear-gradient($white 20%, $darkblue 20%)}
+.bg-split-top-yellow{background: linear-gradient($white 20%, $yellow 20%)}
+.bg-split-top-olive{background: linear-gradient($white 20%, $olive 20%)}
+
 .bg-split-darkblue {background: linear-gradient($white 50%, $darkblue 50%)}
 .bg-split-darkblue-rev {background: linear-gradient($darkblue 50%, $white 50%)}
 
@@ -248,6 +254,10 @@ h1, h2, h3, h4, h5, h6 {
     img {
       max-height: 18rem;
     }
+  }
+
+  .vertical-spacer {
+    height:100px;
   }
 
   .news-item {

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -24,7 +24,7 @@ $mint-lighter-70: #bcede5;
 $mint-lighter-80: #d2f3ed;
 $mint-lighter-90: #e9f9f6;
 
-$lightbluetblue: #4FB3D9;
+$lightblue: #4FB3D9;
 
 $lightblue-darker-10: #47a1c3;
 $lightblue-darker-20: #3f8fae;
@@ -124,19 +124,66 @@ $black: #3A3A3A;
 
 .text-white { color: white; }
 
+//Background
+
 .bg-mint { background: $mint; }
+.bg-mint-light { background: $mint-lighter-50}
+.bg-mint-lighter { background: $mint-lighter-70}
+.bg-mint-dark { background: $mint-darker-50}
+.bg-mint-darker { background: $mint-darker-70}
+
+.bg-lightblue { background: $lightblue; }
+.bg-lightblue-light { background: $lightblue-lighter-50}
+.bg-lightblue-lighter { background: $lightblue-lighter-70}
+.bg-lightblue-dark { background: $lightblue-darker-50}
+.bg-lightblue-darker { background: $lightblue-darker-70}
+
+.bg-darkblue { background: $darkblue; }
+.bg-darkblue-light { background: $darkblue-lighter-50}
+.bg-darkblue-lighter { background: $darkblue-lighter-70}
+.bg-darkblue-dark { background: $darkblue-darker-50}
+.bg-darkblue-darker { background: $darkblue-darker-70}
+
+.bg-yellow { background: $yellow; }
+.bg-yellow-light { background: $yellow-lighter-50}
+.bg-yellow-lighter { background: $yellow-lighter-70}
+.bg-yellow-dark { background: $yellow-darker-50}
+.bg-yellow-darker { background: $yellow-darker-70}
+
+.bg-olive { background: $olive; }
+.bg-olive-light { background: $olive-lighter-50}
+.bg-olive-lighter { background: $olive-lighter-70}
+.bg-olive-dark { background: $olive-darker-50}
+.bg-olive-darker { background: $olive-darker-70}
 
 .bg-split-darkblue {background: linear-gradient($white 50%, $darkblue 50%)}
 .bg-split-darkblue-rev {background: linear-gradient($darkblue 50%, $white 50%)}
 
-.border-mint {border: 2px solid $mint}
+//Border
+.border-mint { border: 2px solid $mint; }
+.border-mint-light { border: 2px solid $mint-lighter-50}
+.border-mint-dark { border: 2px solid $mint-darker-50}
+
+.border-lightblue { border: 2px solid $lightblue; }
+.border-lightblue-light { border: 2px solid $lightblue-lighter-50}
+.border-lightblue-dark { border: 2px solid $lightblue-darker-50}
+
+.border-darkblue { border: 2px solid $darkblue; }
+.border-darkblue-light { border: 2px solid $darkblue-lighter-50}
+.border-darkblue-dark { border: 2px solid $darkblue-darker-50}
+
+.border-yellow { border: 2px solid $yellow; }
+.border-yellow-light { border: 2px solid $yellow-lighter-50}
+.border-yellow-dark { border: 2px solid $yellow-darker-50}
+
+.border-olive { border: 2px solid $olive; }
+.border-olive-light { border: 2px solid $olive-lighter-50}
+.border-olive-dark { border: 2px solid $olive-darker-50}
 
 .text-mint { color: $mint; }
 
-.bg-darkblue { background: $darkblue; }
 .text-darkblue { color: $darkblue; }
 
-.bg-lightblue { background: $lightblue; }
 .text-lightblue { color: $lightblue; }
 
 .bg-lightgray { background: $lightgray; }

--- a/assets/css/custom.scss
+++ b/assets/css/custom.scss
@@ -1,13 +1,123 @@
 $margin: 12px;
 $corner-radius: 12px;
 
+//Base colors and shading
 $mint: #1FC2A7;
-$white: #FEFEFE;
-$black: #3A3A3A;
+
+$mint-darker-10: #1caf96;
+$mint-darker-20: #199b86;
+$mint-darker-30: #168875;
+$mint-darker-40: #137464;
+$mint-darker-50: #106154;
+$mint-darker-60: #0c4e43;
+$mint-darker-70: #093a32;
+$mint-darker-80: #062721;
+$mint-darker-90: #031311;
+
+$mint-lighter-10: #35c8b0;
+$mint-lighter-20: #4cceb9;
+$mint-lighter-30: #62d4c1;
+$mint-lighter-40: #79daca;
+$mint-lighter-50: #8fe1d3;
+$mint-lighter-60: #a5e7dc;
+$mint-lighter-70: #bcede5;
+$mint-lighter-80: #d2f3ed;
+$mint-lighter-90: #e9f9f6;
+
+$lightbluetblue: #4FB3D9;
+
+$lightblue-darker-10: #47a1c3;
+$lightblue-darker-20: #3f8fae;
+$lightblue-darker-30: #377d98;
+$lightblue-darker-40: #2f6b82;
+$lightblue-darker-50: #285a6d;
+$lightblue-darker-60: #204857;
+$lightblue-darker-70: #183641;
+$lightblue-darker-80: #10242b;
+$lightblue-darker-80: #081216;
+
+$lightblue-lighter-10: #61bbdd;
+$lightblue-lighter-20: #72c2e1;
+$lightblue-lighter-30: #84cae4;
+$lightblue-lighter-40: #95d1e8;
+$lightblue-lighter-50: #a7d9ec;
+$lightblue-lighter-60: #b9e1f0;
+$lightblue-lighter-70: #cae8f4;
+$lightblue-lighter-80: #dcf0f7;
+$lightblue-lighter-90: #edf7fb;
+
 $darkblue: #2D3E50;
-$lightblue: #4FB3D9;
-$lightgray: #ECEBEB;
+
+$darkblue-darker-10: #293848;
+$darkblue-darker-20: #243240;
+$darkblue-darker-30: #1f2b38;
+$darkblue-darker-40: #1b2530;
+$darkblue-darker-50: #171f28;
+$darkblue-darker-60: #121920;
+$darkblue-darker-70: #0d1318;
+$darkblue-darker-80: #090c10;
+$darkblue-darker-90: #040608;
+
+$darkblue-lighter-10: #425162;
+$darkblue-lighter-20: #576573;
+$darkblue-lighter-30: #6c7885;
+$darkblue-lighter-40: #818b96;
+$darkblue-lighter-50: #969fa8;
+$darkblue-lighter-60: #abb2b9;
+$darkblue-lighter-70: #c0c5cb;
+$darkblue-lighter-80: #d5d8dc;
+$darkblue-lighter-90: #eaecee;
+
 $yellow: #F9CD69;
+
+$yellow-darker-10: #e6ad00;
+$yellow-darker-20: #cc9a00;
+$yellow-darker-30: #b38600;
+$yellow-darker-40: #997300;
+$yellow-darker-50: #806000;
+$yellow-darker-60: #664d00;
+$yellow-darker-70: #4c3a00;
+$yellow-darker-80: #332600;
+$yellow-darker-90: #191300;
+
+$yellow-lighter-10: #ffc61a;
+$yellow-lighter-20: #ffcd33;
+$yellow-lighter-30: #ffd34d;
+$yellow-lighter-40: #ffd966;
+$yellow-lighter-50: #ffe080;
+$yellow-lighter-60: #ffe699;
+$yellow-lighter-70: #ffecb3;
+$yellow-lighter-80: #fff2cc;
+$yellow-lighter-90: #fff9e6;
+
+$olive: #b4ce82;
+
+$olive-darker-10: #a2b975;
+$olive-darker-20: #90a568;
+$olive-darker-30: #7e905b;
+$olive-darker-40: #6c7c4e;
+$olive-darker-50: #5a6741;
+$olive-darker-60: #485234;
+$olive-darker-70: #363e27;
+$olive-darker-80: #24291a;
+$olive-darker-90: #12150d;
+
+$olive-lighter-10: #bcd38f;
+$olive-lighter-20: #c3d89b;
+$olive-lighter-30: #cbdda8;
+$olive-lighter-40: #d2e2b4;
+$olive-lighter-50: #dae7c1;
+$olive-lighter-60: #e1ebcd;
+$olive-lighter-70: #e9f0da;
+$olive-lighter-80: #f0f5e6;
+$olive-lighter-90: #f8faf3;
+
+$lightgray: #ECEBEB;
+
+$white: #FEFEFE;
+
+$black: #3A3A3A;
+
 
 
 // COLORS
@@ -15,6 +125,12 @@ $yellow: #F9CD69;
 .text-white { color: white; }
 
 .bg-mint { background: $mint; }
+
+.bg-split-darkblue {background: linear-gradient($white 50%, $darkblue 50%)}
+.bg-split-darkblue-rev {background: linear-gradient($darkblue 50%, $white 50%)}
+
+.border-mint {border: 2px solid $mint}
+
 .text-mint { color: $mint; }
 
 .bg-darkblue { background: $darkblue; }

--- a/index.html
+++ b/index.html
@@ -35,8 +35,9 @@ title: Home
 
 <!-- Our Mission -->
 <div class="container-md">
-  <div class="row hero bg-mint">
+  <div class="row hero bg-split-top-mint">
     <div class="hero-image">
+      <div class="vertical-spacer"></div>
       <img src="assets/img/mission.svg" alt="mission statement"/>
     </div>
     <div class="hero-content">
@@ -50,14 +51,15 @@ title: Home
           <a href="/mission.html" class="learn-more">learn more</a>
         </div>      
       </div>
-    </div>
+      <div class="vertical-spacer"></div>
   </div>
 </div>
 
 <!-- Community -->
 <div class="container-md">
-  <div class="row hero bg-darkblue">
+  <div class="row hero bg-split-top-darkblue">
     <div class="hero-image order-1 order-md-2">
+      <div class="vertical-spacer"></div>
       <img src="assets/img/funding-map.svg" alt="plant biology funding map"/>
     </div>
     <div class="hero-content order-2 order-md-1">
@@ -72,16 +74,18 @@ title: Home
             or imaging and is ready to store petabaytes of annotated data.            
           </p>
           <a href="/community.html" class="learn-more">learn more</a>
-        </div>      
+        </div>     
       </div>
+      <div class="vertical-spacer"></div>
     </div>
   </div>
 </div>
 
 <!-- ARC -->
 <div class="container-md">
-  <div class="row hero bg-lightblue">
+  <div class="row hero bg-split-top-lightblue">
     <div class="hero-image">
+      <div class="vertical-spacer"></div>
       <img src="assets/img/arc-overview.svg" alt="overview of annotated research contexts"/>
     </div>
     <div class="hero-content">
@@ -96,14 +100,16 @@ title: Home
           <!-- <a href="/arcs.html" class="learn-more">learn more</a> -->
         </div>      
       </div>
+      <div class="vertical-spacer"></div>
      </div>
   </div>
 </div>
 
 <!-- Service -->
 <div class="container-md">
-  <div class="row hero bg-lightgray">
+  <div class="row hero bg-split-top-olive">
     <div class="hero-image order-1 order-md-2">
+      <div class="vertical-spacer"></div>
       <img class="col-bg" src="assets/img/service.svg" alt="services provided by DataPLANT"/>
     </div>
     <div class="hero-content order-2 order-md-1">
@@ -122,6 +128,7 @@ title: Home
           <!-- <a href="/services.html" class="learn-more">learn more</a> -->
         </div>      
       </div>
+      <div class="vertical-spacer"></div>
     </div>
   </div>
 </div>


### PR DESCRIPTION
This PR adds a demo of the arc page (still as html though) according to previously discussed design. Additionally, many color variables and classes are added to the custom scss file to incorporate colors shown [here](https://github.com/nfdi4plants/Branding)

also moves the headers of the cards on the index page:

![image](https://user-images.githubusercontent.com/21338071/94207187-5c608d80-fec7-11ea-819b-ef9672a827eb.png)

