### PR TITLE
Update event details for ARC workshop in FDM-Werkstatt 2026

### DIFF
--- a/src/content/events/2026-03-24_FDM-Werkstatt-HHU.md
+++ b/src/content/events/2026-03-24_FDM-Werkstatt-HHU.md
@@ -11,14 +11,14 @@ location:
   name: "Haus der Universität (BSR 4A/4B), Düsseldorf"
   url: "https://www.hdu.hhu.de/kontakt"
 tutors:
-  - "Yaser Alashloo ([CEPLAS](https://www.ceplas.eu/en/research/data-science-and-data-management))"
-  - "Sabrina Zander ([MibiNet](https://www.sfb1535.hhu.de/projects/research-area-z/z03))"
-  - "Xiaoran Zhou ([Bioinformatik (IBG-4)](https://www.fz-juelich.de/de/ibg/ibg-4/forschung-1/omics-datenbasierte-bioinformatik/datenbanken-und-data-science-1))"
+  - Yaser Alashloo (<a href="https://www.ceplas.eu/en/research/ceplas-data">CEPLAS Data</a>)
+  - Sabrina Zander (<a href="https://www.sfb1535.hhu.de/projects/research-area-z/z03">MibiNet</a>)
+  - Xiaoran Zhou (<a href="https://www.fz-juelich.de/de/ibg/ibg-4/forschung-1/omics-datenbasierte-bioinformatik/datenbanken-und-data-science-1">Bioinformatik (IBG-4)</a>)
 organizer:
   name: "fdm.nrw in cooperation with the RDM Competence Centre of Heinrich Heine University Düsseldorf, CEPLAS, DataPLANT and NFDI4BIOIMAGE."
-  url: "https://www.ceplas.eu/en/research/data-science-and-data-management"
+  url: "https://www.fdm.nrw/fdm-werkstatt"
 registration:
-    description: 'This workshop is part of [FDM-Werkstatt 2026](https://www.fdm.nrw/fdm-werkstatt).' 
+    description: 'This workshop is part of FDM-Werkstatt 2026.'
     url: "https://eveeno.com/fdmwerkstatt2026duesseldorf"
     seats: 15
 ---
@@ -35,10 +35,6 @@ registration:
 
 Please prepare the following **before** the "Hands-on" workshop.
 
-- Laptop with ARCitect installed (https://github.com/nfdi4plants/ARCitect/releasehttps://nfdi4plants.github.io/nfdi4plants.knowledgebase/arcitect/installation/)
+- Laptop with [ARCitect](https://nfdi4plants.github.io/nfdi4plants.knowledgebase/arcitect/) installed 
 - Sign up for a DataHUB user account: https://register.nfdi4plants.org/
 - elabFTW Account (If you don’t have access via your organization, you can use the DataPLANT Test Instance, https://elab.dataplan.top/register.php)
-
-### Teaching Materials
-
-Materials are shared via DataPLANT [Knowledge Base](https://nfdi4plants.org/nfdi4plants.knowledgebase/docs/teaching-materials/events-2024/2024-04-11_MibiNet-CEPLAS-ARC-Trainings/index.html).


### PR DESCRIPTION
Adding the ARC workshop (which is part of the FDM-Werkstatt 2026) to the event page.  